### PR TITLE
text change

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ The easiest way to use Figma-Low-Code is to clone this repository and install No
 git clone https://github.com/KlausSchaefers/figma-low-code.git
 ```
 
+Navigate to the cloned repository
+
+```
+cd figma-low-code
+```
+
 Afterwards, load all dependecies with the following command
 
 ``` sh


### PR DESCRIPTION
Proposed an additional step in "How to install Figma-Low-Code" usage instructing users to first navigate to the said directory before installing dependencies. Proposing the change as I have seen fellow designers who don't code as much make this mistake repeatedly.